### PR TITLE
Fix: PHP 7.4 / PHP 8.1 apache-buster 404 Not Found issue

### DIFF
--- a/bin/php74/Dockerfile
+++ b/bin/php74/Dockerfile
@@ -5,6 +5,10 @@ FROM php:7.4.2-apache-buster
  
 ARG DEBIAN_FRONTEND=noninteractive
 
+RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99ignore-valid-until
+
 # Update
 RUN apt-get -y update --fix-missing && \
     apt-get upgrade -y && \

--- a/bin/php81/Dockerfile
+++ b/bin/php81/Dockerfile
@@ -5,6 +5,10 @@ FROM php:8.1-apache-buster
  
 ARG DEBIAN_FRONTEND=noninteractive
 
+RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99ignore-valid-until
+
 # Update
 RUN apt-get -y update --fix-missing && \
     apt-get upgrade -y && \


### PR DESCRIPTION
With apache-buster image reaching end-of-life (EOL) and no longer being available on the regular Docker mirrors, this update patches the Dockerfile to reference the Debian archive repositories instead.

**Details**
- `php:7.4-apache-buster`/ `php:8.1-apache-buster` is now EOL and removed from active mirrors.
- `debian:bullseye` and `debian:bookworm` are the preferred current bases, but for compatibility we temporarily use the Debian archives to fetch the legacy image.
- This change ensures continued build stability until a full migration to a supported base image is completed.