### PR TITLE
Fix PHP 8.2.1 apache-buster 404 Not Found issue

### DIFF
--- a/bin/php82/Dockerfile
+++ b/bin/php82/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.1-apache-buster
+FROM php:8.2.1-apache
 
 # Surpresses debconf complaints of trying to install apt packages interactively
 # https://github.com/moby/moby/issues/4032#issuecomment-192327844


### PR DESCRIPTION
This PR updates the base image in the Dockerfile from:

FROM php:8.2.1-apache-buster
to:
FROM php:8.2.1-apache

The previous image (-buster) was based on Debian 10, which is now EOL. Its repositories have been archived, causing 404 Not Found errors during apt-get update.