### PR TITLE
Feat: Support MySQL/MariaDB configuration via mounted my.cnf

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ _**MYSQL_LOG_DIR**_
 
 This will be used to store Apache logs. The default value for this is `./logs/mysql`.
 
+_**MYSQL_CNF**_
+
+Define your custom `my.cnf` modifications to meet your database requirments.
+
 ## Web Server
 
 Apache is configured to run on port 80. So, you can access it via `http://localhost`.

--- a/config/mysql/my.cnf
+++ b/config/mysql/my.cnf
@@ -1,0 +1,3 @@
+[mysql]
+
+[mysqld]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - ${MYSQL_INITDB_DIR-./config/initdb}:/docker-entrypoint-initdb.d
       - ${MYSQL_DATA_DIR-./data/mysql}:/var/lib/mysql
       - ${MYSQL_LOG_DIR-./logs/mysql}:/var/log/mysql
+      - ${MYSQL_CNF-./config/mysql/my.cnf}:/etc/my.cnf
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}

--- a/sample.env
+++ b/sample.env
@@ -31,6 +31,7 @@ DATABASE=mysql8
 MYSQL_INITDB_DIR=./config/initdb
 MYSQL_DATA_DIR=./data/mysql
 MYSQL_LOG_DIR=./logs/mysql
+MYSQL_CNF=./config/mysql/my.cnf
 
 # If you already have the port 80 in use, you can change it (for example if you have Apache)
 HOST_MACHINE_UNSECURE_HOST_PORT=80


### PR DESCRIPTION
Allow configuring MySQL and MariaDB through an external `my.cnf` file mounted as a Docker volume. This lets users override default settings (e.g. buffer sizes, connection limits, charset, table case) without rebuilding the image.

- Added `my.cnf` volume mount support in Docker setup
- Ensured container startup loads external config
- Improves flexibility for custom database tuning