### PR TITLE
Add shared database socket support and WebP GD support for PHP 8.4

### DIFF
--- a/bin/php84/Dockerfile
+++ b/bin/php84/Dockerfile
@@ -13,6 +13,11 @@ RUN apt-get -y update --fix-missing && \
 
 RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
+RUN { \
+    echo 'pdo_mysql.default_socket=/run/mysqld/mysqld.sock'; \
+    echo 'mysqli.default_socket=/run/mysqld/mysqld.sock'; \
+} > /usr/local/etc/php/conf.d/docker-mysql-socket.ini
+
 # Install useful tools and install important libaries
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends install nano wget \

--- a/bin/php84/Dockerfile
+++ b/bin/php84/Dockerfile
@@ -83,9 +83,10 @@ RUN docker-php-ext-install pdo_mysql && \
 RUN apt-get -y update && \
     apt-get --no-install-recommends install -y libfreetype6-dev \
 libjpeg62-turbo-dev \
+libwebp-dev \
 libpng-dev && \
     rm -rf /var/lib/apt/lists/* && \
-    docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg && \
+    docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp && \
     docker-php-ext-install gd
 
 # Insure an SSL directory exists

--- a/config/php/php.ini
+++ b/config/php/php.ini
@@ -2,6 +2,8 @@ memory_limit = 256M
 post_max_size = 100M
 upload_max_filesize = 100M
 
+pdo_mysql.default_socket = /run/mysqld/mysqld.sock
+
 # Xdebug 2
 #xdebug.remote_enable=1
 #xdebug.remote_autostart=1

--- a/config/php/php.ini
+++ b/config/php/php.ini
@@ -3,6 +3,7 @@ post_max_size = 100M
 upload_max_filesize = 100M
 
 pdo_mysql.default_socket = /run/mysqld/mysqld.sock
+mysqli.default_socket = /run/mysqld/mysqld.sock
 
 # Xdebug 2
 #xdebug.remote_enable=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ${VHOSTS_DIR-./config/vhosts}:/etc/apache2/sites-enabled
       - ${LOG_DIR-./logs/apache2}:/var/log/apache2
       - ${XDEBUG_LOG_DIR-./logs/xdebug}:/var/log/xdebug
+      - ${MYSQL_SOCKET_DIR-./data/mysql-socket}:/run/mysqld
     environment:
       APACHE_DOCUMENT_ROOT: ${APACHE_DOCUMENT_ROOT-/var/www/html}
       PMA_PORT: ${HOST_MACHINE_PMA_PORT}
@@ -39,10 +40,13 @@ services:
     volumes:
       - ${MYSQL_INITDB_DIR-./config/initdb}:/docker-entrypoint-initdb.d
       - ${MYSQL_DATA_DIR-./data/mysql}:/var/lib/mysql
+      - ${MYSQL_SOCKET_DIR-./data/mysql-socket}:/run/mysqld
       - ${MYSQL_LOG_DIR-./logs/mysql}:/var/log/mysql
       - ${MYSQL_CNF-./config/mysql/my.cnf}:/etc/my.cnf
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "yes"
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}


### PR DESCRIPTION
## Summary

This PR improves the Docker setup by adding shared database socket support between the webserver and database containers, and enables WebP support for the PHP 8.4 GD extension.

  ## Changes
- Mounts a shared MySQL/MariaDB socket directory into both the webserver and database containers.
- Configures `pdo_mysql.default_socket` to use `/run/mysqld/mysqld.sock`.
- Adds empty-password compatibility environment variables for MySQL/MariaDB local development setups.
- Adds `libwebp-dev` to the PHP 8.4 image.
- Enables WebP support in the PHP 8.4 GD extension using `--with-webp`.

## Why

This allows PHP applications to connect to the database through the local Unix socket when available, which is useful for MariaDB/MySQL-compatible local development environments. It also brings PHP 8.4 GD support in line with common image-processing needs by enabling WebP handling.

## Testing

Tested by rebuilding the PHP 8.4 container and verifying the updated Docker Compose configuration includes the shared socket mount.
